### PR TITLE
do not use format!() in assert!()

### DIFF
--- a/src/periodic_cashflow/irr.rs
+++ b/src/periodic_cashflow/irr.rs
@@ -44,11 +44,9 @@ mod tests {
         let precision = (irr(&cf, guess).unwrap() - -0.08364541746615000000000000000000).abs();
         assert!(
             precision <= PRECISION,
-            format!(
-                "IRR of {}, exceeded IRR precision threshold, {}",
-                irr(&cf, guess).unwrap(),
-                precision
-            )
+            "IRR of {}, exceeded IRR precision threshold, {}",
+            irr(&cf, guess).unwrap(),
+            precision
         );
     }
 
@@ -59,11 +57,9 @@ mod tests {
         let precision = (irr(&cf, guess).unwrap() - -0.08364541746615000000000000000000).abs();
         assert!(
             precision <= PRECISION,
-            format!(
-                "exceeded {} IRR precision threshold, {}",
-                irr(&cf, guess).unwrap(),
-                precision
-            )
+            "exceeded {} IRR precision threshold, {}",
+            irr(&cf, guess).unwrap(),
+            precision
         );
     }
 

--- a/src/periodic_cashflow/mirr.rs
+++ b/src/periodic_cashflow/mirr.rs
@@ -2,7 +2,7 @@ use crate::common::utils;
 
 /// Returns the modified internal rate of return for a series of periodic cash flows.
 /// MIRR considers both the cost of the investment and the interest received on reinvestment of cash.
-/// 
+///
 /// # Example
 /// ```
 /// let cf = [-1000., 100., 200., 300., 400., 400., 400.];
@@ -41,15 +41,13 @@ mod tests {
         let finance_rate = 0.1;
         let reinvest_rate = 0.1;
         let mirr = mirr(&cf, finance_rate, reinvest_rate);
-        
+
         let ans = 0.138453832579;
         assert!(
            (mirr - ans).abs() <= PRECISION,
-            format!(
-                "ans is {} got {}",
-                ans,
-                mirr
-            )
+           "ans is {} got {}",
+           ans,
+           mirr
         );
     }
 
@@ -59,16 +57,14 @@ mod tests {
         let finance_rate = 0.05;
         let reinvest_rate = 0.1;
         let mirr = mirr(&cf, finance_rate, reinvest_rate);
-        
+
         let ans = 0.16288556821502476;
         assert!(
            (mirr - ans).abs() <= PRECISION,
-            format!(
-                "ans is {} got {}",
-                ans,
-                mirr
-            )
-        );        
+           "ans is {} got {}",
+           ans,
+           mirr
+        );
     }
 
     #[test]
@@ -77,15 +73,13 @@ mod tests {
         let finance_rate = 0.05;
         let reinvest_rate = 0.1;
         let mirr = mirr(&cf, finance_rate, reinvest_rate);
-        
+
         let ans = f64::INFINITY;
         assert!(
            mirr.is_infinite(),
-            format!(
-                "ans is {} got {}",
-                ans,
-                mirr
-            )
-        );        
+           "ans is {} got {}",
+           ans,
+           mirr
+        );
     }
 }


### PR DESCRIPTION
The compiler said it will an error in Rust 2021

```
warning: panic message is not a string literal
  --> src/periodic_cashflow/irr.rs:62:13
   |
62 | /             format!(
63 | |                 "exceeded {} IRR precision threshold, {}",
64 | |                 irr(&cf, guess).unwrap(),
65 | |                 precision
66 | |             )
   | |_____________^
   |
   = note: this usage of assert!() is deprecated; it will be a hard error in Rust 2021
   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
   = note: the assert!() macro supports formatting, so there's no need for the format!() macro here
help: remove the `format!(..)` macro call
   |
62 ~             
63 |                 "exceeded {} IRR precision threshold, {}",
64 |                 irr(&cf, guess).unwrap(),
65 |                 precision
66 ~             
   |
```